### PR TITLE
Add link to guidelines on how to install ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,5 @@ Before doing anything with `rbevn` the following setup are [recommended](https:/
 > ```ruby
 > brew install bison
 > ```
+
+Finally to install ruby versions follow [Installing Ruby versions](https://github.com/rbenv/rbenv#installing-ruby-versions) guideline. 


### PR DESCRIPTION
This, PR simply adds link on how to install ruby versions using [rbenv](https://github.com/rbenv/rbenv#installing-ruby-versions).